### PR TITLE
fix : move refresh token to httpOnly cookie #163

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -7,11 +7,13 @@ const api = axios.create({
     baseURL: API_CONFIG.BASE_URL,
     timeout: API_CONFIG.TIMEOUT,
     headers: API_CONFIG.HEADERS,
+    withCredentials: true,  // HttpOnly 쿠키 전송을 위해 필수
 });
 
 const fileApi = axios.create({
     baseURL: API_CONFIG.BASE_URL,
     timeout: API_CONFIG.TIMEOUT,
+    withCredentials: true,  // HttpOnly 쿠키 전송을 위해 필수
 });
 
 // 토큰 갱신 중인지 여부
@@ -84,26 +86,18 @@ api.interceptors.response.use(
                 originalRequest._retry = true;
                 isRefreshing = true;
 
-                const refreshToken = localStorage.getItem('refreshToken');
-
-                if (!refreshToken) {
-                    // Refresh Token이 없으면 로그인 페이지로
-                    isRefreshing = false;
-                    useAuthStore.getState().clearAuth();
-                    window.location.href = '/login';
-                    return Promise.reject(error);
-                }
-
                 try {
-                    // 토큰 갱신 요청
-                    const response = await axios.post(`${API_CONFIG.BASE_URL}/auth/reissue`, {
-                        refreshToken: refreshToken
-                    });
+                    // 토큰 갱신 요청 (Refresh Token은 HttpOnly 쿠키로 자동 전송)
+                    const response = await axios.post(
+                        `${API_CONFIG.BASE_URL}/auth/reissue`,
+                        {},  // body 없음 - 쿠키로 전송
+                        { withCredentials: true }
+                    );
 
-                    const { accessToken, refreshToken: newRefreshToken } = response.data;
+                    const { accessToken } = response.data;
 
-                    // 새 토큰 저장
-                    useAuthStore.getState().setTokens(accessToken, newRefreshToken);
+                    // 새 Access Token 저장
+                    useAuthStore.getState().setToken(accessToken);
 
                     // 대기 중인 요청들 처리
                     processQueue(null, accessToken);
@@ -191,22 +185,16 @@ fileApi.interceptors.response.use(
                 originalRequest._retry = true;
                 isRefreshing = true;
 
-                const refreshToken = localStorage.getItem('refreshToken');
-
-                if (!refreshToken) {
-                    isRefreshing = false;
-                    useAuthStore.getState().clearAuth();
-                    window.location.href = '/login';
-                    return Promise.reject(error);
-                }
-
                 try {
-                    const response = await axios.post(`${API_CONFIG.BASE_URL}/auth/reissue`, {
-                        refreshToken: refreshToken
-                    });
+                    // 토큰 갱신 요청 (Refresh Token은 HttpOnly 쿠키로 자동 전송)
+                    const response = await axios.post(
+                        `${API_CONFIG.BASE_URL}/auth/reissue`,
+                        {},  // body 없음 - 쿠키로 전송
+                        { withCredentials: true }
+                    );
 
-                    const { accessToken, refreshToken: newRefreshToken } = response.data;
-                    useAuthStore.getState().setTokens(accessToken, newRefreshToken);
+                    const { accessToken } = response.data;
+                    useAuthStore.getState().setToken(accessToken);
                     processQueue(null, accessToken);
 
                     originalRequest.headers.Authorization = `Bearer ${accessToken}`;

--- a/src/features/auth/api/authService.js
+++ b/src/features/auth/api/authService.js
@@ -3,21 +3,21 @@ import axios from 'axios';
 import { API_CONFIG } from '../../../api/config';
 
 export const authService = {
-  // 로그인
+  // 로그인 (Refresh Token은 HttpOnly 쿠키로 자동 설정됨)
   login: async (loginData) => {
     try {
       const response = await api.post('/auth/login', {
         memberAccount: loginData.memberAccount,
         password: loginData.password
       });
-      return response.data; // { accessToken: "...", refreshToken: "..." }
+      return response.data; // { accessToken: "..." } - refreshToken은 쿠키로 설정됨
     } catch (error) {
       console.error('로그인 API 에러:', error);
       throw error;
     }
   },
 
-  // 로그아웃
+  // 로그아웃 (Refresh Token 쿠키도 서버에서 삭제됨)
   logout: async () => {
     try {
       const response = await api.post('/auth/logout');
@@ -28,13 +28,15 @@ export const authService = {
     }
   },
 
-  // 토큰 갱신
-  reissue: async (refreshToken) => {
+  // 토큰 갱신 (Refresh Token은 쿠키로 자동 전송됨)
+  reissue: async () => {
     try {
-      const response = await axios.post(`${API_CONFIG.BASE_URL}/auth/reissue`, {
-        refreshToken: refreshToken
-      });
-      return response.data; // { accessToken: "...", refreshToken: "..." }
+      const response = await axios.post(
+        `${API_CONFIG.BASE_URL}/auth/reissue`,
+        {},  // body 없음 - Refresh Token은 쿠키로 전송
+        { withCredentials: true }
+      );
+      return response.data; // { accessToken: "..." } - refreshToken은 쿠키로 설정됨
     } catch (error) {
       console.error('토큰 갱신 에러:', error);
       throw error;

--- a/src/features/auth/model/useAuthStore.js
+++ b/src/features/auth/model/useAuthStore.js
@@ -1,34 +1,34 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+/**
+ * 인증 상태 관리 스토어
+ * - Access Token은 localStorage에 저장
+ * - Refresh Token은 HttpOnly Cookie로 서버에서 관리 (XSS 방어)
+ */
 export const useAuthStore = create(
   persist(
     (set, get) => ({
       user: null,
       token: null,
-      refreshToken: null,
       isAuthenticated: false,
 
-      // 로그인
-      login: (userData, accessToken, refreshToken) => {
+      // 로그인 (Refresh Token은 쿠키로 자동 설정됨)
+      login: (userData, accessToken) => {
         localStorage.setItem('token', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
         set({
           user: userData,
           token: accessToken,
-          refreshToken: refreshToken,
           isAuthenticated: true
         });
       },
 
-      // 로그아웃
+      // 로그아웃 (Refresh Token 쿠키는 서버에서 삭제)
       logout: () => {
         localStorage.removeItem('token');
-        localStorage.removeItem('refreshToken');
         set({
           user: null,
           token: null,
-          refreshToken: null,
           isAuthenticated: false
         });
       },
@@ -38,36 +38,21 @@ export const useAuthStore = create(
         set({ user: userData });
       },
 
-      // 토큰 설정 (토큰 갱신 시 사용)
-      setTokens: (accessToken, refreshToken) => {
+      // Access Token 설정 (토큰 갱신 시 사용)
+      setToken: (accessToken) => {
         localStorage.setItem('token', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
         set({
           token: accessToken,
-          refreshToken: refreshToken,
           isAuthenticated: true
         });
-      },
-
-      // 토큰 설정 (기존 호환성 유지)
-      setToken: (token) => {
-        localStorage.setItem('token', token);
-        set({ token, isAuthenticated: true });
-      },
-
-      // Refresh Token 가져오기
-      getRefreshToken: () => {
-        return get().refreshToken || localStorage.getItem('refreshToken');
       },
 
       // 인증 상태 초기화
       clearAuth: () => {
         localStorage.removeItem('token');
-        localStorage.removeItem('refreshToken');
         set({
           user: null,
           token: null,
-          refreshToken: null,
           isAuthenticated: false
         });
       }
@@ -76,7 +61,6 @@ export const useAuthStore = create(
       name: 'auth-storage',
       partialize: (state) => ({
         user: state.user,
-        refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated
       })
     }

--- a/src/features/auth/ui/Login.jsx
+++ b/src/features/auth/ui/Login.jsx
@@ -50,13 +50,12 @@ export const Login = () => {
         password: formData.password
       });
 
-      // 2. 토큰 저장 (accessToken, refreshToken)
-      const { accessToken, refreshToken } = loginResponse;
+      // 2. Access Token 추출 (Refresh Token은 HttpOnly 쿠키로 자동 설정됨)
+      const { accessToken } = loginResponse;
 
       // 3. 토큰으로 사용자 정보 가져오기
       // JWT 토큰을 먼저 localStorage에 저장해야 getMyInfo가 동작함
       localStorage.setItem('token', accessToken);
-      localStorage.setItem('refreshToken', refreshToken);
 
       try {
         const userInfo = await authService.getMyInfo();
@@ -66,7 +65,7 @@ export const Login = () => {
           ...userInfo,
           id: userInfo.memberId || userInfo.id
         };
-        login(authUser, accessToken, refreshToken);
+        login(authUser, accessToken);
 
         // 5. 프로필 설정 (백엔드 데이터만 사용)
         let newProfile = null;
@@ -166,7 +165,7 @@ export const Login = () => {
       } catch (infoError) {
         console.error('사용자 정보 조회 실패:', infoError);
         // 사용자 정보 조회 실패 시에도 토큰은 유효하므로 기본 페이지로 이동
-        login({ memberAccount: formData.memberAccount }, accessToken, refreshToken);
+        login({ memberAccount: formData.memberAccount }, accessToken);
         navigate('/mypage');
       }
 
@@ -175,7 +174,6 @@ export const Login = () => {
 
       // 로그인 실패 시 토큰 제거
       localStorage.removeItem('token');
-      localStorage.removeItem('refreshToken');
 
       if (err.code === 'ERR_NETWORK') {
         // 1. 네트워크 에러 (백엔드 서버 다운 등)

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => {
       server: {
         port: 3000,
         host: '0.0.0.0',
+        // 백엔드 API 프록시 설정 (HttpOnly 쿠키 전송을 위해 same-origin 필요)
+        proxy: {
+          '/api': {
+            target: 'http://localhost:8888',
+            changeOrigin: true,
+          }
+        }
       },
       plugins: [react()],
       define: {


### PR DESCRIPTION
#163 

-내용
refresh 토큰을 로컬이 아닌 httpOnly를 통해 쿠기에 저장하여 보안성을 높인다.
-작업
로컬에 refresh 토큰을 저장하여 refresh 토큰 rotation을 써도 해커가 사용자보다 먼저 발급을 받을시 문제가 생겨 refresh을 쿠기에 저장시켜 xss공격을 막아 보안성을 높인다.